### PR TITLE
Improve robustness of allowed extensions handling

### DIFF
--- a/octoprint_uploadanything/__init__.py
+++ b/octoprint_uploadanything/__init__.py
@@ -27,7 +27,7 @@ class UploadAnythingPlugin(octoprint.plugin.TemplatePlugin,
 	def get_extension_tree(self, *args, **kwargs):
 		return dict(
 			model=dict(
-				uploadanything=self.allowed.replace(" ", "").split(",")
+				uploadanything=[x for x in self.allowed.replace(" ", "").split(",") if x != '']
 			)
 		)
 		


### PR DESCRIPTION
I have noticed that I can no longer create directories if the allowed extensions string ends with a comma, i.e 'stl, '.
The given example would result in the list ['stl', ''] after `split(",")` causing the problems, which I have not tragged down any further.
So here is a simple fix which avoids empty strings in the list. Since I am not an experienced python programmer, I am open for feedback.